### PR TITLE
CI: add smoke health workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -17,9 +17,10 @@ jobs:
         run: npm run build
       - name: Start API
         run: |
-          npm install --prefix /tmp/api https://github.com/yohand-byte/solaire-api.git --no-progress --omit=dev || true
-          cd /tmp/api/node_modules/solaire-api
-          npm install --omit=dev
+          git clone https://github.com/yohand-byte/solaire-api.git /tmp/api
+          cd /tmp/api
+          npm ci
+          npm run build
           node dist/index.js &
           echo $! > /tmp/api-server.pid
       - name: Wait for API health


### PR DESCRIPTION
Adds a smoke test workflow that builds the frontend, starts the API, waits for /health and asserts 200.