### PR TITLE
feat: expose client portal entry

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ import { API_URL } from "./api/client";
 import LoginAdmin from "./admin/LoginAdmin.tsx";
 import { HealthDebug } from "./debug/HealthDebug";
 import { MessagesDebug } from "./debug/MessagesDebug";
+import Landing from "./Landing.jsx";
 
 const API_BASE = API_URL;
 const API_TOKEN = 'saftoken-123';
@@ -1151,8 +1152,8 @@ export default function App() {
       <Route path="/client/dossiers" element={<ClientRoute><ClientFiles /></ClientRoute>} />
       <Route path="/client/dossiers/:id" element={<ClientRoute><ClientFileDetail /></ClientRoute>} />
 
-      <Route path="/" element={<Navigate to="/dashboard" replace />} />
-      <Route path="/*" element={<Navigate to="/dashboard" replace />} />
+      <Route path="/" element={<Landing />} />
+      <Route path="/*" element={<Navigate to="/" replace />} />
     </Routes>
   );
 }

--- a/src/Landing.jsx
+++ b/src/Landing.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function Landing() {
+  return (
+    <div className="landing">
+      <header className="landing-hero">
+        <div>
+          <p className="pill soft">Solaire Facile</p>
+          <h1>Admin & Portail Client réunis</h1>
+          <p className="hero-sub">Suivi dossiers, consuel, enedis et documents en temps réel.</p>
+          <div className="cta-row">
+            <Link className="btn-primary" to="/client/login">Espace client</Link>
+            <Link className="btn-secondary" to="/login">Espace admin</Link>
+          </div>
+        </div>
+      </header>
+      <section className="landing-cards">
+        <div className="card">
+          <h3>Suivi temps réel</h3>
+          <p>Accès direct au tableau de bord client pour consulter l'avancement.</p>
+        </div>
+        <div className="card">
+          <h3>Documents centralisés</h3>
+          <p>DP, Consuel, Enedis : tout au même endroit, partage sécurisée.</p>
+        </div>
+        <div className="card">
+          <h3>Support dédié</h3>
+          <p>Chat en direct et notifications par email intégrées.</p>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a landing page with CTA to /client/login plus routes root->Landing to surface the client dashboard entry point.