### PR TITLE
docs(audit): baseline 2026-01-18 + ADRs + runbooks + templates + backlog

### DIFF
--- a/.github/ISSUE_TEMPLATE/architecture_adr.yml
+++ b/.github/ISSUE_TEMPLATE/architecture_adr.yml
@@ -1,0 +1,50 @@
+name: "Architecture / ADR"
+description: "Changement d’architecture cadré par une ADR (sans exécution ici)."
+title: "[P1][ARCH] <résumé>"
+labels: ["P1", "architecture", "adr"]
+body:
+  - type: input
+    id: adr_ref
+    attributes:
+      label: "ADR liée (obligatoire)"
+      placeholder: "ADR-0002"
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: "Contexte / problème"
+      placeholder: "Pourquoi on change, symptôme, contrainte “sans régression CRM”."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: "Décision / proposition"
+      placeholder: "Composants, frontières, flux, auth, données."
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: "Scope + non-scope"
+      placeholder: "Ce qui est inclus/exclu (pas de refonte CRM)."
+    validations:
+      required: true
+  - type: textarea
+    id: milestones
+    attributes:
+      label: "Plan / jalons"
+      placeholder: |
+        M1: design + contrat API
+        M2: implémentation
+        M3: tests + rollout
+    validations:
+      required: true
+  - type: textarea
+    id: dod
+    attributes:
+      label: "Definition of Done"
+      placeholder: "Tests, docs, monitoring, rollback documenté."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/decommission.yml
+++ b/.github/ISSUE_TEMPLATE/decommission.yml
@@ -1,0 +1,41 @@
+name: "Decommission / Retrait"
+description: "Retrait contrôlé (service/secret/bucket) avec preuve d’inutilité + rollback."
+title: "[DECOM] <résumé>"
+labels: ["cleanup", "decommission"]
+body:
+  - type: textarea
+    id: inventory
+    attributes:
+      label: "Inventaire à retirer (obligatoire)"
+      placeholder: "Service(s), routes, secrets (noms), buckets (noms), IAM bindings."
+    validations:
+      required: true
+  - type: textarea
+    id: evidence_unused
+    attributes:
+      label: "Preuve UNUSED (obligatoire)"
+      description: "Logs, absence d’appels, absence de dépendances, code refs."
+      placeholder: "Ex: 30j sans trafic + aucune référence code + aucun caller."
+    validations:
+      required: true
+  - type: textarea
+    id: plan
+    attributes:
+      label: "Plan de retrait (obligatoire)"
+      placeholder: "Étapes, fenêtre, monitoring, critères de stop."
+    validations:
+      required: true
+  - type: textarea
+    id: rollback
+    attributes:
+      label: "Rollback (obligatoire)"
+      placeholder: "Réactiver service, restaurer IAM/spec, remettre secret version."
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: "Validation post-retrait (obligatoire)"
+      placeholder: "Dashboards/logs, tests fonctionnels, absence d’erreurs."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/security_p0.yml
+++ b/.github/ISSUE_TEMPLATE/security_p0.yml
@@ -1,0 +1,67 @@
+name: "P0 Sécurité"
+description: "Durcissement immédiat (IAM Run, secrets, IAM projet, Firestore) avec preuve + rollback."
+title: "[P0][SEC] <résumé>"
+labels: ["P0", "security"]
+body:
+  - type: textarea
+    id: evidence
+    attributes:
+      label: "Preuve actuelle (obligatoire)"
+      description: |
+        Inclure références aux exports (ex: /tmp/run_iam/*.json, /tmp/cloudrun_curl.log, /tmp/project_iam/*.json).
+        Aucune valeur de secret en clair.
+      placeholder: |
+        - /tmp/run_iam/... montre allUsers roles/run.invoker
+        - /tmp/cloudrun_curl.log montre 200/400 sans auth
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: "Scope + non-scope"
+      placeholder: |
+        Scope: services/projets concernés.
+        Non-scope: pas de modification de logique métier, pas de refonte UI, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: plan
+    attributes:
+      label: "Plan de changement (haut niveau) (obligatoire)"
+      description: "Étapes séquentielles, une action à la fois, avec points de contrôle."
+      placeholder: |
+        1) Backup IAM/spec/ruleset
+        2) Appliquer changement sur 1 service
+        3) Valider (curl/IAM/logs)
+        4) Étendre au service suivant
+    validations:
+      required: true
+  - type: textarea
+    id: rollout
+    attributes:
+      label: "Rollout (ordre exact des services)"
+      placeholder: |
+        Ordre: <service1> -> <service2> -> ...
+        Gates: 401/403 attendus, smoke test UI, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: rollback
+    attributes:
+      label: "Rollback (obligatoire)"
+      placeholder: |
+        - run services set-iam-policy depuis backup
+        - update-traffic vers révision précédente
+        - releases update vers ruleset précédent
+    validations:
+      required: true
+  - type: textarea
+    id: dod
+    attributes:
+      label: "Definition of Done (obligatoire)"
+      placeholder: |
+        - Preuve post-change (exports + curl)
+        - Aucun allUsers non voulu
+        - Aucun endpoint sensible accessible anonymement
+    validations:
+      required: true

--- a/docs/adr/ADR-0001-cloud-run-invocation.md
+++ b/docs/adr/ADR-0001-cloud-run-invocation.md
@@ -1,0 +1,27 @@
+# ADR-0001 — Cloud Run: public vs privé, stratégie d’invocation
+
+Status: Proposed
+
+## Context
+Baseline: tous les services Cloud Run listés ont `allUsers` sur roles/run.invoker. Des endpoints répondent 200/400/404 sans auth sur “/” et “/api”. Objectif: réduire surface exposée sans casser le CRM.
+
+## Decision
+- Modèle “privé par défaut”.
+- Seuls les frontends statiques explicitement publics restent accessibles anonymement.
+- Tous les services API / DP / webhooks / callable deviennent privés et sont invoqués via:
+  - IAM invoker (service accounts) et/ou
+  - façade unique (proxy) contrôlée.
+
+## Consequences
+- Nécessite de définir les identités autorisées (SA appelants).
+- Tests curl sur endpoints privés doivent retourner 401/403.
+- Réduction immédiate du risque d’exposition.
+
+## Alternatives (rejetées)
+- Tout laisser public + “clés côté serveur”: fuite probable / posture faible.
+- IP allowlist: fragile, maintenance élevée.
+- mTLS bout en bout: disproportionné pour ce scope.
+
+## Rollback
+- Réappliquer les policies IAM sauvegardées sur les services concernés (run services set-iam-policy).
+---

--- a/docs/adr/ADR-0002-dp-integration-orchestrator-proxy.md
+++ b/docs/adr/ADR-0002-dp-integration-orchestrator-proxy.md
@@ -1,0 +1,32 @@
+# ADR-0002 — Intégration DP sans régression CRM: Orchestrator + Proxy
+
+Status: Proposed
+
+## Context
+DP Generator et services associés (dp-generator, solaire-dp-generator, html-carto-api) sont aujourd’hui accessibles via Cloud Run public. Le CRM doit rester intact (MASTER CRM = référence). Objectif: intégrer/industrialiser DP sans toucher la fonctionnalité CRM, et clarifier l’appel des services.
+
+## Decision
+- Introduire un service “dp-orchestrator” (Cloud Run) responsable de:
+  - déclenchement génération DP,
+  - orchestration multi-étapes (validation carto, multi-parcelles, etc.),
+  - statut et récupération output.
+- Exposer au frontend uniquement une façade “proxy” côté API de référence:
+  - Le frontend CRM appelle `POST/GET /dp/*` sur l’API de référence.
+  - L’API de référence appelle l’orchestrator (privé).
+  - L’orchestrator appelle dp-generator/solaire-dp-generator/html-carto-api (privés).
+
+## Consequences
+- DP services deviennent privés (IAM invoker).
+- Traçabilité: request-id, logs corrélés, statut exploitable côté UI.
+- “Sans régression CRM”: aucune modification de logique CRM existante, seulement ajout d’un chemin DP isolé.
+
+## Alternatives (rejetées)
+- Appels directs du frontend vers DP services: exposition + coupling.
+- Iframe: CORS/SSO fragile, UX dégradée.
+- Monorepo/merge total: risque de régression et temps long.
+
+## Rollback
+- Revenir au mode actuel (URLs DP publiques) en documentant la bascule:
+  - réactiver l’accès public si nécessaire via IAM backup,
+  - désactiver l’orchestrator/proxy sans impacter le CRM.
+---

--- a/docs/adr/ADR-0003-image-pinning-secrets-iam.md
+++ b/docs/adr/ADR-0003-image-pinning-secrets-iam.md
@@ -1,0 +1,28 @@
+# ADR-0003 — Pin images, Secret Manager, IAM moindre privilège
+
+Status: Proposed
+
+## Context
+Baseline: usage de `:latest` et tags non digest + token en clair (API_PROXY_TOKEN sur gentle) + rôles IAM larges (roles/editor, storage.admin, cross-project datastore.user). Objectif: améliorer traçabilité, rollback, et réduire blast radius.
+
+## Decision
+- Cloud Run déployé sur digest uniquement: `image@sha256:...`.
+- Secrets uniquement via Secret Manager:
+  - Cloud Run: secretKeyRef
+  - Cloud Functions: secretEnv / secretKeyRef
+- IAM: suppression des rôles larges au profit de rôles ciblés au besoin.
+
+## Consequences
+- Rollback fiable: retour révision/image consignée.
+- Rotation secrets possible.
+- Nécessite une discipline pipeline (capturer digest, versionner décisions).
+
+## Alternatives (rejetées)
+- Garder tags flottants: non traçable, rollback faible.
+- Secrets en env plaintext: fuite + rotation difficile.
+- roles/editor “pour aller vite”: dette et exposition.
+
+## Rollback
+- Réaffecter image précédente (tag ou revision) et restaurer IAM depuis backups.
+- En dernier recours: rétablir env plaintext (uniquement si blocage critique).
+---

--- a/docs/audit/2026-01-18/00-scope.md
+++ b/docs/audit/2026-01-18/00-scope.md
@@ -1,0 +1,42 @@
+# 00 — Périmètre, contraintes, sources
+
+## Objectif
+Figer une baseline d’audit (inventaire + exposition + risques + plan + rollback) et préparer la traçabilité GitHub (ADR, runbooks, templates, backlog).
+ZÉRO changement infra. ZÉRO déploiement. ZÉRO modification de code applicatif.
+
+## Projets dans le périmètre
+- gentle-mapper-479320-j1 (828508661560) — MASTER CRM (référence)
+- solaire-frontend (29459740400) — DP Generator + services associés
+- solaire-admin (294963767896)
+- mcp-gcp-prod (596239108234)
+- mcp-gcp-prod-481314 (568369588098)
+
+## Contraintes absolues (read-only)
+- Aucun changement IAM / Firestore / Storage / Secrets / Cloud Run / Cloud Functions.
+- Aucune activation d’API (si prompt d’activation → consigné “API disabled”).
+- Tests HTTP uniquement HEAD / GET / OPTIONS sur “/” et “/api” (aucun POST/PUT/PATCH/DELETE).
+- Aucun secret en clair (uniquement des noms de variables et références de secrets).
+- Toute action future (P0/P1/P2) doit passer par une issue GitHub avec preuve + rollback + DoD.
+
+## Sources de preuves (exports)
+- Cloud Run describe: /tmp/run_describes/*.json
+- Cloud Run IAM: /tmp/run_iam/*.json
+- IAM projets: /tmp/project_iam/*.json
+- Tests HTTP: /tmp/cloudrun_curl.log
+- Firestore: /tmp/firestore/* (db_desc, indexes, ruleset)
+- IdentityToolkit: /tmp/identitytoolkit/*.json
+- Buckets: /tmp/buckets/* (list, desc, iam)
+- Secrets (uniquement solaire-frontend): /tmp/secrets/solaire-frontend_*.json
+- APIs activées: /tmp/apis/*.txt
+- Images: /tmp/solaire_frontend_image_tags.txt, /tmp/master_crm_tags.json
+
+## Constats baseline (sans débat, consignés)
+- Cloud Run: invoker `allUsers` (roles/run.invoker) sur tous les services listés.
+- Endpoints répondent sans auth (200/400/404) sur “/” et parfois “/api”.
+- Images non figées: `:latest` et/ou tags non digest sur certains services.
+- Secrets: Secret Manager actif surtout sur solaire-frontend; ailleurs, API Secret Manager souvent désactivée. Au moins un token (API_PROXY_TOKEN) existe en clair dans env sur gentle.
+- IAM projets: présence de rôles larges (ex: roles/editor) sur SAs génériques; cas de cross-project datastore.user; storage.admin sur un compute SA sur mcp-gcp-prod-481314.
+- Firestore: solaire-admin règles permissives (auth != null => read/write /**). gentle-mapper sans ruleset publié. solaire-frontend règles plus restrictives côté write.
+- IdentityToolkit: actif sur solaire-frontend et solaire-admin; désactivé/403 sur gentle/mcp*.
+- Firebase: actif sur solaire-frontend et solaire-admin; non confirmé/absent sur gentle-mapper et mcp*.
+---

--- a/docs/audit/2026-01-18/01-inventory-by-project.md
+++ b/docs/audit/2026-01-18/01-inventory-by-project.md
@@ -1,0 +1,158 @@
+# 01 — Inventaire par projet
+
+Notation:
+- Public Run: présence de `allUsers` sur roles/run.invoker (cf. /tmp/run_iam/*.json)
+- Secrets: uniquement noms (Secret Manager) ou “env plaintext” si observé
+- Valeurs exactes non présentes dans les preuves → `TBD`
+
+## gentle-mapper-479320-j1 (828508661560)
+
+### Cloud Run (4 services)
+| Service | URL canonique | URL a.run.app (test) | Image | Service Account | Public Run | Secrets / Env | Notes |
+|---|---|---|---|---|---|---|---|
+| cerfa-api | https://cerfa-api-828508661560.europe-west1.run.app | https://cerfa-api-xfwqgqc7ca-ew.a.run.app | @sha256:19fcff… | 828508661560-compute@developer.gserviceaccount.com | Oui | env: API_KEY | “/” retourne 404 |
+| crm-webhook | https://crm-webhook-828508661560.europe-west1.run.app | https://crm-webhook-xfwqgqc7ca-ew.a.run.app | @sha256:0cd4e4… | 828508661560-compute@developer.gserviceaccount.com | Oui | none | “/” retourne 200 |
+| solaire-api | https://solaire-api-828508661560.europe-west1.run.app | https://solaire-api-xfwqgqc7ca-ew.a.run.app | @sha256:1c4a6b… | 828508661560-compute@developer.gserviceaccount.com | Oui | env: CADASTRE_BUFFER_M, GOOGLE_CLOUD_PROJECT, GCLOUD_PROJECT | “/” retourne 200 |
+| solaire-frontend (master-crm) | https://solaire-frontend-828508661560.europe-west1.run.app | https://solaire-frontend-xfwqgqc7ca-ew.a.run.app | master-crm:pwa-nginx2 (tag non digest) | 828508661560-compute@developer.gserviceaccount.com | Oui | env plaintext: API_PROXY_TARGET, API_PROXY_TOKEN, API_PROXY_PREFIX, DEPLOY_TS | Front statique (200) |
+
+### Cloud Functions
+- Aucune listée (API Cloud Functions signalée désactivée dans les preuves).
+
+### Firestore
+- Base: FIRESTORE_NATIVE (europe-west1), PITR disabled.
+- Rules: aucune release publiée observée (releases none).
+
+### IdentityToolkit / Auth
+- API désactivée (403) dans les preuves.
+
+### Storage buckets (extraits)
+- gentle-mapper-479320-j1_cloudbuild
+- run-sources-gentle-mapper-479320-j1-europe-west1
+- solaire-facile-documents
+- yohan-cloud-backup-{codex,temp}
+IAM bucket: pas de allUsers/allAuthenticated observé. UBLA/PAP: null (à durcir dans remédiation).
+
+### Secret Manager
+- API Secret Manager désactivée (SERVICE_DISABLED) dans les preuves.
+
+### IAM projet (extraits)
+- roles/editor sur SA compute.
+- owner user.
+- cloudbuild.builds.editor user.
+
+---
+
+## solaire-frontend (29459740400)
+
+### Cloud Run (7 services)
+| Service | URL canonique | URL a.run.app (test) | Image | Service Account | Public Run | Secrets / Env | Notes |
+|---|---|---|---|---|---|---|---|
+| core-api | https://core-api-29459740400.europe-west1.run.app | https://core-api-z5hnfoy7ya-ew.a.run.app | @sha256:efed990… | 29459740400-compute@developer.gserviceaccount.com | Oui | none | “/” 404 |
+| dp-generator | https://dp-generator-29459740400.europe-west1.run.app | https://dp-generator-z5hnfoy7ya-ew.a.run.app | @sha256:7e3f0d… | 29459740400-compute@developer.gserviceaccount.com | Oui | secretKeyRef: google-maps-api-key (GOOGLE_API_KEY) | “/” GET 200 |
+| html-carto-api | https://html-carto-api-29459740400.europe-west1.run.app | https://html-carto-api-z5hnfoy7ya-ew.a.run.app | gcr.io/solaire-frontend/html-carto-api (tag non digest) | 29459740400-compute@developer.gserviceaccount.com | Oui | none | “/” GET 200 |
+| sendclientmagiclink | https://sendclientmagiclink-29459740400.europe-west1.run.app | https://sendclientmagiclink-z5hnfoy7ya-ew.a.run.app | gcf-artifacts:version_1 | 29459740400-compute@developer.gserviceaccount.com | Oui | secretKeyRef: SMTP_* | “/” GET 400 (callable) |
+| solaire-api | https://solaire-api-29459740400.europe-west1.run.app | https://solaire-api-z5hnfoy7ya-ew.a.run.app | @sha256:3b5d5e… | 29459740400-compute@developer.gserviceaccount.com | Oui | env: FRONTEND_ORIGIN, CONTINUE_URL, FIREBASE_WEB_API_KEY, DEBUG_RETURN_LINK, ADMIN_API_KEY | “/” 404 |
+| solaire-dp-generator | https://solaire-dp-generator-29459740400.europe-west1.run.app | https://solaire-dp-generator-z5hnfoy7ya-ew.a.run.app | @sha256:63b172… | 29459740400-compute@developer.gserviceaccount.com | Oui | secretKeyRef: google-maps-api-key, solaire-api-token | “/” GET 200 |
+| solaire-frontend | https://solaire-frontend-29459740400.europe-west1.run.app | https://solaire-frontend-z5hnfoy7ya-ew.a.run.app | eu.gcr.io/solaire-frontend/solaire-frontend:latest (digest 94bcfb4d5a21) | 29459740400-compute@developer.gserviceaccount.com | Oui | secretKeyRef: solaire-api-token (API_PROXY_TOKEN) | Front statique (200) |
+
+### Cloud Functions (Gen2)
+- sendClientMagicLink: callable; ingress ALLOW_ALL; secrets SMTP_* référencés (versions v1/v2 observées).
+
+### Firestore
+- Base: FIRESTORE_NATIVE (nam5), PITR disabled.
+- Indexes: 11 composites (clients, credits_transactions, documents, dossiers, files, leads, projectDocuments_v2, projects).
+- Ruleset: présent (admin-only write; reads auth selon collections).
+
+### IdentityToolkit / Auth
+- Email/password: enabled.
+- authorizedDomains incluent: localhost, firebaseapp.com, web.app, et certains run.app (selon export).
+
+### Storage buckets (extraits)
+- gcf-v2-sources-29459740400-*
+- gcf-v2-uploads-29459740400.*.cloudfunctions.appspot.com
+- run-sources-solaire-frontend-europe-west1
+- solaire-frontend_cloudbuild
+IAM bucket: pas de allUsers/allAuthenticated observé. UBLA/PAP: null.
+
+### Secret Manager (liste observée)
+- OPENAI_API_KEY
+- google-maps-api-key
+- solaire-api-token
+- SMTP_HOST / SMTP_PORT / SMTP_USER / SMTP_PASS / SMTP_FROM / SMTP_SECURE
+
+### IAM projet (extraits)
+- roles/editor sur compute/cloudservices/appspot.
+- roles/datastore.user inclut un membre cross-project (828508661560-compute).
+- roles/firebaseauth.admin sur adminsdk + un SA applicatif (selon export).
+- user owner + run.admin + iam.serviceAccountAdmin.
+
+---
+
+## solaire-admin (294963767896)
+
+### Cloud Run
+- Aucun service listé.
+
+### Cloud Functions
+- Aucune listée.
+
+### Firestore
+- Base: FIRESTORE_NATIVE (nam5), PITR disabled.
+- Ruleset: permissif (auth != null => read/write /**) + règle spécifique leads create (champs min).
+
+### IdentityToolkit / Auth
+- Email/password: enabled.
+- authorizedDomains: localhost, firebaseapp.com, web.app (selon export).
+
+### Storage
+- Liste buckets vide dans les preuves (à revalider si nécessaire).
+
+### Secret Manager
+- API Secret Manager désactivée (SERVICE_DISABLED) dans les preuves.
+
+### IAM projet (extraits)
+- roles/editor sur compute + appspot.
+- firebaseauth.admin sur adminsdk.
+- user owner.
+
+---
+
+## mcp-gcp-prod (596239108234)
+
+### Cloud Run (2 services)
+| Service | URL canonique | URL a.run.app (test) | Image | Service Account | Public Run | Secrets / Env | Notes |
+|---|---|---|---|---|---|---|---|
+| mcp-api | https://mcp-api-596239108234.europe-west1.run.app | https://mcp-api-tui46uz4wa-ew.a.run.app | @sha256:b1614c… | 596239108234-compute@developer.gserviceaccount.com | Oui | none | “/” 404 |
+| solaire-api | https://solaire-api-596239108234.europe-west1.run.app | https://solaire-api-tui46uz4wa-ew.a.run.app | @sha256:96a6bd… | 596239108234-compute@developer.gserviceaccount.com | Oui | none | “/” 404 |
+
+### Storage
+- run-sources-mcp-gcp-prod-europe-west1 (IAM: pas de allUsers observé; UBLA/PAP null).
+
+### Secret Manager / Firestore / IdentityToolkit / Functions
+- APIs signalées désactivées dans les preuves.
+
+### IAM projet (extraits)
+- roles/editor sur SA compute.
+- user owner.
+
+---
+
+## mcp-gcp-prod-481314 (568369588098)
+
+### Cloud Run (1 service)
+| Service | URL canonique | URL a.run.app (test) | Image | Service Account | Public Run | Secrets / Env | Notes |
+|---|---|---|---|---|---|---|---|
+| mcp-router | https://mcp-router-568369588098.europe-west1.run.app | https://mcp-router-abrokygzpa-ew.a.run.app | @sha256:445733… | 568369588098-compute@developer.gserviceaccount.com | Oui | env names: ANTHROPIC_API_KEY, OPENAI_API_KEY, MISTRAL_API_KEY | “/” GET 200 |
+
+### Storage
+- run-sources-mcp-gcp-prod-481314-europe-west1 (IAM: pas de allUsers observé; UBLA/PAP null).
+
+### IAM projet (extraits)
+- roles/editor + roles/storage.admin sur SA compute.
+- user owner.
+
+---
+
+## Synthèse duplications
+- “solaire-api” existe dans 3 projets (gentle-mapper, solaire-frontend, mcp-gcp-prod): dérive possible + ambiguïté opérationnelle.
+---

--- a/docs/audit/2026-01-18/02-exposure-http-tests.md
+++ b/docs/audit/2026-01-18/02-exposure-http-tests.md
@@ -1,0 +1,23 @@
+# 02 — Exposition HTTP (tests read-only)
+
+Source: /tmp/cloudrun_curl.log (HEAD/GET/OPTIONS sur “/” et “/api”, sans auth).
+
+| Projet | Service | URL test | “/” (H/G/O) | “/api” (H/G/O) | Notes |
+|---|---|---|---|---|---|
+| gentle-mapper | cerfa-api | https://cerfa-api-xfwqgqc7ca-ew.a.run.app | 404/404/404 | 404/404/404 | JSON court |
+| gentle-mapper | crm-webhook | https://crm-webhook-xfwqgqc7ca-ew.a.run.app | 200/200/200 | 200/200/200 | x-powered-by: Express |
+| gentle-mapper | solaire-api | https://solaire-api-xfwqgqc7ca-ew.a.run.app | 200/200/204 | 404/404/204 | CORS methods larges observées |
+| gentle-mapper | solaire-frontend | https://solaire-frontend-xfwqgqc7ca-ew.a.run.app | 200/200/405 | 200/200/405 | static HTML |
+| mcp-gcp-prod | mcp-api | https://mcp-api-tui46uz4wa-ew.a.run.app | 404/404/404 | 404/404/404 | CSP strict |
+| mcp-gcp-prod | solaire-api | https://solaire-api-tui46uz4wa-ew.a.run.app | 404/404/204 | 404/404/204 | OPTIONS 204 |
+| mcp-gcp-prod-481314 | mcp-router | https://mcp-router-abrokygzpa-ew.a.run.app | 200/200/200 | 404/404/404 | ACAO: * observé |
+| solaire-frontend | core-api | https://core-api-z5hnfoy7ya-ew.a.run.app | 404/404/204 | 404/404/204 | OPTIONS 204 |
+| solaire-frontend | dp-generator | https://dp-generator-z5hnfoy7ya-ew.a.run.app | 405/200/405 | 404/404/404 | GET “/” répond |
+| solaire-frontend | html-carto-api | https://html-carto-api-z5hnfoy7ya-ew.a.run.app | 405/200/405 | 404/404/404 | GET “/” répond |
+| solaire-frontend | sendclientmagiclink | https://sendclientmagiclink-z5hnfoy7ya-ew.a.run.app | 400/400/204 | 400/400/204 | callable, POST attendu |
+| solaire-frontend | solaire-api | https://solaire-api-z5hnfoy7ya-ew.a.run.app | 404/404/204 | 404/404/204 | OPTIONS 204 |
+| solaire-frontend | solaire-dp-generator | https://solaire-dp-generator-z5hnfoy7ya-ew.a.run.app | 200/200/204 | 404/404/204 | GET “/” répond |
+| solaire-frontend | solaire-frontend | https://solaire-frontend-z5hnfoy7ya-ew.a.run.app | 200/200/405 | 200/200/405 | static HTML |
+
+Conclusion baseline: aucune barrière 401/403 observée sur ces endpoints “/” et “/api”, et l’IAM Run montre allUsers sur roles/run.invoker pour tous les services listés.
+---

--- a/docs/audit/2026-01-18/03-risk-register.md
+++ b/docs/audit/2026-01-18/03-risk-register.md
@@ -1,0 +1,22 @@
+# 03 — Registre des risques (baseline)
+
+Références de preuve:
+- IAM Run: /tmp/run_iam/*.json
+- HTTP: /tmp/cloudrun_curl.log
+- Images: /tmp/solaire_frontend_image_tags.txt, /tmp/master_crm_tags.json, /tmp/run_describes/*.json
+- IAM projet: /tmp/project_iam/*.json
+- Firestore rules: /tmp/firestore/*_ruleset.json, releases (si présents)
+- Buckets: /tmp/buckets/*_desc.json, /tmp/buckets/*_iam.json
+
+| ID | Sévérité | Risque | Preuve | Impact | Correctif minimal | Rollback |
+|---|---|---|---|---|---|---|
+| R-001 | P0 | Cloud Run invoker public (allUsers) sur tous les services | /tmp/run_iam/*.json | Exposition anonyme (API + surfaces internes) | Retirer allUsers, ajouter invokers autorisés (SA / identité) | Réappliquer IAM Run sauvegardé |
+| R-002 | P0 | Endpoints répondent sans auth (200/400/404) | /tmp/cloudrun_curl.log | Surface attaquable, fingerprinting, abus potentiels | IAM privé + ingress/auth (selon service) | Restaurer IAM/spec |
+| R-003 | P0 | Images non figées (:latest / tags non digest) | /tmp/run_describes/*.json, /tmp/solaire_frontend_image_tags.txt, /tmp/master_crm_tags.json | Rollback difficile, dérive supply-chain | Pin par digest | Retour révision précédente / image précédente |
+| R-004 | P0 | Secret en clair (API_PROXY_TOKEN) sur gentle master-crm | /tmp/run_describes/*gentle*.json | Fuite de jeton, rotation impossible | Migrer vers Secret Manager + secretKeyRef | Rétablir env plaintext (dernier recours) |
+| R-005 | P0 | IAM projet trop large (roles/editor, storage.admin, cross-project datastore.user) | /tmp/project_iam/*.json | Escalade latérale, blast radius | Moindre privilège (rôles ciblés) | set-iam-policy depuis backup |
+| R-006 | P0 | Firestore solaire-admin: RW global si auth | /tmp/firestore/solaire-admin_ruleset.json | Toute auth Firebase => RW large | Règles par collection/rôle | Revenir ruleset précédent |
+| R-007 | P1 | Buckets UBLA/PAP non forcés (null) | /tmp/buckets/*_desc.json | Posture non durcie, risque futur | UBLA=ON, PAP=ENFORCED, CORS minimal | Restaurer config bucket |
+| R-008 | P1 | “solaire-api” dupliqué sur 3 projets | Inventaire | Ambiguïté + drift | Contrat unique + plan de décommission | Garder mapping actuel |
+| R-009 | P1 | Service callable sendClientMagicLink exposé (invoker public + ingress ALLOW_ALL) | /tmp/run_iam/*, /tmp/run_describes/*, /tmp/cloudrun_curl.log | Abus (spam, coûts), surface auth | Retirer public + vérifier auth callable | Restaurer IAM/ingress |
+---

--- a/docs/audit/2026-01-18/04-used-vs-obsolete.md
+++ b/docs/audit/2026-01-18/04-used-vs-obsolete.md
@@ -1,0 +1,20 @@
+# 04 — Used vs Obsolete (baseline prudente)
+
+But: classifier sans “inventer” d’usage. Toute ligne doit soit (a) référencer une preuve, soit (b) rester “Incertain”.
+
+| Statut | Élément | Preuve minimale | Caller / Flux | Données touchées | Notes / Action |
+|---|---|---|---|---|---|
+| Utilisé (confirmé) | solaire-frontend (master-crm) | HTTP 200 sur “/” | Navigateur / CRM | UI | Rester public seulement si explicitement voulu |
+| Utilisé (confirmé) | solaire-frontend (proj solaire-frontend) | HTTP 200 sur “/” | Navigateur / PWA | UI | À maintenir, mais IAM à cadrer |
+| Utilisé (confirmé) | dp-generator | HTTP GET 200 sur “/” | Flux DP | Dossiers DP | Doit devenir privé derrière proxy/orchestrator |
+| Utilisé (confirmé) | html-carto-api | HTTP GET 200 sur “/” | Flux carto | Carto / HTML | Image non figée; doit devenir privé si sensible |
+| Utilisé (confirmé) | solaire-dp-generator | HTTP GET 200 sur “/” | Flux DP | DP | Doit devenir privé derrière proxy/orchestrator |
+| Utilisé (confirmé) | mcp-router | HTTP GET 200 sur “/” | Gateway MCP | JSON | Contient env names LLM; à durcir |
+| Incertain | cerfa-api | HTTP 404 sur “/” | TBD | TBD | Confirmer si endpoint réel ≠ “/” |
+| Incertain | crm-webhook | HTTP 200 sur “/” | Webhooks | Payloads | Identifier producteurs/consommateurs |
+| Incertain | solaire-api (gentle) | HTTP 200 sur “/” | CRM API | CRM | Nom trompeur (200 sur “/” peut être placeholder) |
+| Incertain | solaire-api (proj solaire-frontend) | HTTP 404 sur “/” | API | CRM/DP | Endpoint réel probablement autre que “/” |
+| Candidate decommission | solaire-api (mcp-gcp-prod) | HTTP 404 sur “/” et “/api” | TBD | TBD | Décommission seulement après preuve “unused” |
+| Candidate decommission | mcp-api | HTTP 404 sur “/” et “/api” | TBD | TBD | Décommission seulement après preuve “unused” |
+| Incertain | yohan-cloud-backup-* buckets | Inventaire buckets | Admin | Backups | Hors prod; documenter but, puis décider |
+---

--- a/docs/audit/2026-01-18/05-remediation-plan.md
+++ b/docs/audit/2026-01-18/05-remediation-plan.md
@@ -1,0 +1,61 @@
+# 05 — Plan de remédiation (proposé, non exécuté)
+
+Objectif: sécuriser d’abord (P0), puis architecture (P1), puis intégration UI (P2), sans régression CRM.
+
+## P0 — Sécurité immédiate (sans changement fonctionnel)
+1) Cloud Run: privé par défaut
+- Retirer allUsers sur tous les services non explicitement publics.
+- Ajouter invokers autorisés (service accounts + identités).
+- Validation: HEAD/GET attendus 401/403 sur services privés, 200 seulement sur fronts statiques.
+
+2) sendClientMagicLink (Gen2 callable): fermer l’anonyme
+- Retirer allUsers et cadrer ingress.
+- Vérifier côté function: exiger request.auth (contrat callable).
+
+3) Pin images
+- Remplacer :latest et tags non digest par image@sha256:digest.
+- Priorité: master-crm:pwa-nginx2, html-carto-api, solaire-frontend:latest.
+
+4) Secrets
+- Migrer API_PROXY_TOKEN (gentle) vers Secret Manager + secretKeyRef.
+- Inventorier et supprimer (plus tard) les secrets orphelins uniquement après preuve d’inutilité.
+
+5) IAM projet
+- Remplacer roles/editor + storage.admin par rôles minimaux.
+- Retirer cross-project datastore.user si non strictement requis.
+
+6) Firestore
+- solaire-admin: remplacer RW global (auth != null) par règles par collection/rôle.
+- gentle-mapper: publier un ruleset explicite (deny-by-default ou accès ciblé).
+
+## P1 — Architecture (sans toucher la fonctionnalité CRM)
+1) Orchestrator DP (Cloud Run dédié)
+- Nouveau service “dp-orchestrator”.
+- DP services deviennent privés; l’orchestrator appelle en interne.
+- Traçabilité: request-id / logs / statut.
+
+2) Proxy côté API “référence”
+- Ajouter une façade unique “/dp/*” côté API de référence (sans casser CRM).
+- Le frontend n’appelle jamais dp-generator directement.
+
+3) Normalisation “solaire-api”
+- Décider l’API de référence (MASTER CRM).
+- Planifier la convergence et le décommission progressif des duplicats.
+
+4) Stockage outputs DP
+- Bucket privé dédié outputs (PAP enforced + UBLA).
+- Accès via URL signée courte durée ou proxy authentifié.
+
+## P2 — Intégration UI CRM (sans régression)
+1) UI: bouton “Générer DP” + suivi statut
+- Appel vers proxy/orchestrator, affichage progression, erreurs.
+
+2) UI: téléchargement sécurisé
+- Lien via URL signée short-lived ou endpoint proxy.
+
+## Règle opérationnelle
+Aucun changement n’est exécuté sans:
+- Issue GitHub (preuve + plan + rollback + DoD)
+- Backup IAM/spec/ruleset avant action
+- Test de validation documenté
+---

--- a/docs/audit/2026-01-18/06-rollback-runbook.md
+++ b/docs/audit/2026-01-18/06-rollback-runbook.md
@@ -1,0 +1,36 @@
+# 06 — Runbook rollback (standard)
+
+## 1) Sauvegardes avant tout changement
+- IAM projet:
+  - gcloud projects get-iam-policy <PROJECT_ID> > backup/iam-<PROJECT_ID>.yaml
+- IAM Cloud Run:
+  - gcloud run services get-iam-policy <SERVICE> --project=<PROJECT_ID> --region=europe-west1 > backup/run-<PROJECT_ID>-<SERVICE>-iam.yaml
+- Spec Cloud Run:
+  - gcloud run services describe <SERVICE> --project=<PROJECT_ID> --region=europe-west1 --format=json > backup/run-<PROJECT_ID>-<SERVICE>-spec.json
+- Révision + image courante:
+  - gcloud run services describe <SERVICE> --project=<PROJECT_ID> --region=europe-west1 --format='value(status.latestReadyRevisionName,spec.template.spec.containers[0].image)' > backup/run-<PROJECT_ID>-<SERVICE>-rev-image.txt
+- Firestore rules:
+  - firebaserules releases list --project <PROJECT_ID> > backup/firestore-releases-<PROJECT_ID>.txt
+  - firebaserules rulesets list --project <PROJECT_ID> > backup/firestore-rulesets-<PROJECT_ID>.txt
+  - (si connu) firebaserules rulesets get <RULESET_ID> --project <PROJECT_ID> > backup/firestore-ruleset-<PROJECT_ID>-<RULESET_ID>.json
+- Buckets:
+  - gcloud storage buckets describe gs://<BUCKET> --format=json > backup/bucket-<BUCKET>.json
+  - gcloud storage buckets get-iam-policy gs://<BUCKET> --format=json > backup/bucket-<BUCKET>-iam.json
+
+## 2) Rollback Cloud Run IAM
+- gcloud run services set-iam-policy <SERVICE> backup/run-<PROJECT_ID>-<SERVICE>-iam.yaml --project=<PROJECT_ID> --region=europe-west1
+
+## 3) Rollback Cloud Run trafic / révision
+- gcloud run services update-traffic <SERVICE> --project=<PROJECT_ID> --region=europe-west1 --to-revisions <REV>=100
+
+## 4) Rollback image (si update image)
+- gcloud run services update <SERVICE> --project=<PROJECT_ID> --region=europe-west1 --image <OLD_IMAGE>
+
+## 5) Rollback Firestore rules
+- firebaserules releases update cloud.firestore --project <PROJECT_ID> --ruleset <OLD_RULESET_ID>
+
+## 6) Vérifications post-rollback
+- Rejouer HEAD/GET/OPTIONS sur “/” et “/api” (mêmes commandes que l’audit) et consigner.
+- Vérifier IAM (présence/absence allUsers conforme au rollback attendu).
+- Vérifier la révision active Cloud Run.
+---

--- a/docs/runbooks/runbook-cloudrun-iam-hardening.md
+++ b/docs/runbooks/runbook-cloudrun-iam-hardening.md
@@ -1,0 +1,22 @@
+# Runbook — Durcissement IAM Cloud Run
+
+## Objectif
+Retirer l’invocation anonyme et définir des invokers autorisés, avec rollback immédiat.
+
+## Procédure
+1) Backup IAM (obligatoire)
+- gcloud run services get-iam-policy <SVC> --project=<PROJ> --region=europe-west1 > backup/run-<PROJ>-<SVC>-iam.yaml
+
+2) Retirer l’anonyme
+- gcloud run services remove-iam-policy-binding <SVC> --project=<PROJ> --region=europe-west1 --member=allUsers --role=roles/run.invoker
+
+3) Ajouter invokers autorisés
+- gcloud run services add-iam-policy-binding <SVC> --project=<PROJ> --region=europe-west1 --member=serviceAccount:<CALLER_SA> --role=roles/run.invoker
+
+4) Validation
+- curl -I <URL> doit retourner 401/403 (services privés) ou 200 (fronts publics explicitement).
+- gcloud run services get-iam-policy <SVC> --project=<PROJ> --region=europe-west1
+
+## Rollback
+- gcloud run services set-iam-policy <SVC> backup/run-<PROJ>-<SVC>-iam.yaml --project=<PROJ> --region=europe-west1
+---

--- a/docs/runbooks/runbook-firestore-rules-hardening.md
+++ b/docs/runbooks/runbook-firestore-rules-hardening.md
@@ -1,0 +1,23 @@
+# Runbook — Durcissement Firestore Rules
+
+## Sauvegarde
+- firebaserules releases list --project <PROJ>
+- firebaserules rulesets list --project <PROJ>
+- firebaserules rulesets get <RULESET_ID> --project <PROJ> > backup/firestore-ruleset-<PROJ>-<RULESET_ID>.json
+
+## Mise à jour (principe)
+- Deny-by-default.
+- Règles par collection.
+- Writes uniquement pour rôles/admin explicites.
+- Reads uniquement si nécessaire (scopées par userId/tenant).
+
+## Publication
+- firebaserules releases update cloud.firestore --project <PROJ> --ruleset <NEW_RULESET_ID>
+
+## Validation
+- Tests applicatifs lecture/écriture par rôle.
+- Vérifier absence d’accès large “auth != null => /**”.
+
+## Rollback
+- firebaserules releases update cloud.firestore --project <PROJ> --ruleset <OLD_RULESET_ID>
+---

--- a/docs/runbooks/runbook-image-pinning.md
+++ b/docs/runbooks/runbook-image-pinning.md
@@ -1,0 +1,21 @@
+# Runbook — Pinning des images Cloud Run (digest only)
+
+1) Backup spec
+- gcloud run services describe <SVC> --project=<PROJ> --region=europe-west1 --format=json > backup/run-<PROJ>-<SVC>-spec.json
+
+2) Identifier digest
+- Artifact Registry:
+  - gcloud artifacts docker tags list <LOC>-docker.pkg.dev/<PROJ>/<REPO>/<IMAGE> --limit=50
+- GCR:
+  - gcloud container images list-tags eu.gcr.io/<PROJ>/<IMAGE> --limit=50
+
+3) Update service avec digest
+- gcloud run services update <SVC> --project=<PROJ> --region=europe-west1 --image <IMAGE>@sha256:<DIGEST>
+
+4) Validation
+- gcloud run services describe <SVC> --project=<PROJ> --region=europe-west1 --format='value(spec.template.spec.containers[0].image)'
+
+Rollback
+- Revenir à la révision précédente:
+  - gcloud run services update-traffic <SVC> --project=<PROJ> --region=europe-west1 --to-revisions <REV_PREV>=100
+---


### PR DESCRIPTION
Ajoute la baseline d’audit 2026-01-18 (inventaire/exposition/risques/plan/rollback), 3 ADR, 3 runbooks, et templates d’issues. Aucun changement infra, aucun déploiement, aucun changement de code applicatif.